### PR TITLE
Fix read noise casting bug

### DIFF
--- a/satsim/image/noise.py
+++ b/satsim/image/noise.py
@@ -60,6 +60,6 @@ def add_read_noise(fpa, rn, en=0):
         A `Tensor`, the 2D tensor read noise.
     """
     rn = tf.cast(rn, tf.float32)
-    en = tf.cast(rn, tf.float32)
+    en = tf.cast(en, tf.float32)
     noise = tf.random.normal(tf.shape(fpa)) * tf.math.sqrt(rn * rn + en * en)
     return fpa + noise, noise

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -63,3 +63,20 @@ def test_read_noise():
 
     np.testing.assert_approx_equal(stat.mean, val, significant=2)
     np.testing.assert_approx_equal(stat.variance, rn * rn + en * en, significant=2)
+
+
+def test_read_noise_diff_vals():
+    sx = 100
+    sy = 100
+
+    val = 1000
+    a = tf.ones([sx, sy]) * val
+
+    rn = 10
+    en = 3
+    b, _ = add_read_noise(a, rn, en)
+
+    stat = describe(b.numpy().flatten())
+
+    np.testing.assert_approx_equal(stat.mean, val, significant=2)
+    np.testing.assert_approx_equal(stat.variance, rn * rn + en * en, significant=2)


### PR DESCRIPTION
## Summary
- fix incorrect casting for read noise in `add_read_noise`
- add regression test demonstrating correct handling of different RN and EN values

## Testing
- `pytest -q tests/test_noise.py`