### PR TITLE
Improve vecmath with numpy backend

### DIFF
--- a/satsim/vecmath/Cartesian2.py
+++ b/satsim/vecmath/Cartesian2.py
@@ -1,5 +1,7 @@
 import math
 
+from .backend import xp
+
 
 class Cartesian2:
     """ A 2D Cartesian point. """
@@ -22,6 +24,46 @@ class Cartesian2:
             self is other or
             (self.x == other.x and self.y == other.y)
         )
+
+    # ------------------------------------------------------------------
+    # Convenience helpers using numpy/cupy
+    # ------------------------------------------------------------------
+    def to_array(self):
+        """Return a 2-element array representation using the configured backend."""
+        return xp.asarray([self.x, self.y], dtype=float)
+
+    @classmethod
+    def from_array(cls, arr):
+        """Create a :class:`Cartesian2` from a numpy/cupy array."""
+        return cls(arr[0], arr[1])
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+
+    def __add__(self, other):
+        if isinstance(other, Cartesian2):
+            return Cartesian2(self.x + other.x, self.y + other.y)
+        arr = self.to_array() + other
+        return Cartesian2.from_array(arr)
+
+    def __sub__(self, other):
+        if isinstance(other, Cartesian2):
+            return Cartesian2(self.x - other.x, self.y - other.y)
+        arr = self.to_array() - other
+        return Cartesian2.from_array(arr)
+
+    def __mul__(self, scalar):
+        arr = self.to_array() * scalar
+        return Cartesian2.from_array(arr)
+
+    def __truediv__(self, scalar):
+        arr = self.to_array() / scalar
+        return Cartesian2.from_array(arr)
+
+    def __neg__(self):
+        arr = -self.to_array()
+        return Cartesian2.from_array(arr)
 
     @staticmethod
     def fromElements(x, y, result=None):
@@ -197,7 +239,8 @@ class Cartesian2:
         Returns:
             A `float`, The squared magnitude.
         """
-        return cartesian.x * cartesian.x + cartesian.y * cartesian.y
+        arr = cartesian.to_array()
+        return xp.dot(arr, arr)
 
     @staticmethod
     def magnitude(cartesian):
@@ -209,7 +252,8 @@ class Cartesian2:
         Returns:
             A `float`, The magnitude.
         """
-        return math.sqrt(Cartesian2.magnitudeSquared(cartesian))
+        arr = cartesian.to_array()
+        return xp.linalg.norm(arr)
 
     @staticmethod
     def distance(left, right):
@@ -222,8 +266,8 @@ class Cartesian2:
         Returns:
             A `float`, The distance between two points.
         """
-        Cartesian2.subtract(left, right, _distanceScratch)
-        return Cartesian2.magnitude(_distanceScratch)
+        diff = left.to_array() - right.to_array()
+        return xp.linalg.norm(diff)
 
     @staticmethod
     def distanceSquared(left, right):
@@ -237,8 +281,8 @@ class Cartesian2:
         Returns:
             A `float`, The distance between two points.
         """
-        Cartesian2.subtract(left, right, _distanceScratch)
-        return Cartesian2.magnitudeSquared(_distanceScratch)
+        diff = left.to_array() - right.to_array()
+        return xp.dot(diff, diff)
 
     @staticmethod
     def normalize(cartesian, result):
@@ -251,9 +295,10 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        magnitude = Cartesian2.magnitude(cartesian)
-        result.x = cartesian.x / magnitude
-        result.y = cartesian.y / magnitude
+        arr = cartesian.to_array()
+        magnitude = xp.linalg.norm(arr)
+        result.x = arr[0] / magnitude
+        result.y = arr[1] / magnitude
         return result
 
     @staticmethod
@@ -267,7 +312,7 @@ class Cartesian2:
         Returns:
             A `float`, The dot product.
         """
-        return left.x * right.x + left.y * right.y
+        return xp.dot(left.to_array(), right.to_array())
 
     @staticmethod
     def cross(left, right):
@@ -294,8 +339,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = left.x * right.x
-        result.y = left.y * right.y
+        arr = left.to_array() * right.to_array()
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -310,8 +356,9 @@ class Cartesian2:
         Returns:
             A `float`, The modified result parameter.
         """
-        result.x = left.x / right.x
-        result.y = left.y / right.y
+        arr = left.to_array() / right.to_array()
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -326,8 +373,9 @@ class Cartesian2:
         Returns:
             A `float`, The modified result parameter.
         """
-        result.x = left.x + right.x
-        result.y = left.y + right.y
+        arr = left.to_array() + right.to_array()
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -342,8 +390,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = left.x - right.x
-        result.y = left.y - right.y
+        arr = left.to_array() - right.to_array()
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -358,8 +407,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = cartesian.x * scalar
-        result.y = cartesian.y * scalar
+        arr = cartesian.to_array() * scalar
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -374,8 +424,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = cartesian.x / scalar
-        result.y = cartesian.y / scalar
+        arr = cartesian.to_array() / scalar
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -389,8 +440,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = -cartesian.x
-        result.y = -cartesian.y
+        arr = -cartesian.to_array()
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod
@@ -404,8 +456,9 @@ class Cartesian2:
         Returns:
             A `Cartesian2`, The modified result parameter.
         """
-        result.x = abs(cartesian.x)
-        result.y = abs(cartesian.y)
+        arr = xp.abs(cartesian.to_array())
+        result.x = arr[0]
+        result.y = arr[1]
         return result
 
     @staticmethod

--- a/satsim/vecmath/Cartesian3.py
+++ b/satsim/vecmath/Cartesian3.py
@@ -1,5 +1,7 @@
 import math
 
+from .backend import xp
+
 
 class Cartesian3:
     """ A 3D Cartesian point. """
@@ -26,6 +28,45 @@ class Cartesian3:
                 self.y == other.y and
                 self.z == other.z)
         )
+
+    # ------------------------------------------------------------------
+    # Convenience helpers using numpy/cupy
+    # ------------------------------------------------------------------
+    def to_array(self):
+        return xp.asarray([self.x, self.y, self.z], dtype=float)
+
+    @classmethod
+    def from_array(cls, arr):
+        return cls(arr[0], arr[1], arr[2])
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+        yield self.z
+
+    def __add__(self, other):
+        if isinstance(other, Cartesian3):
+            return Cartesian3(self.x + other.x, self.y + other.y, self.z + other.z)
+        arr = self.to_array() + other
+        return Cartesian3.from_array(arr)
+
+    def __sub__(self, other):
+        if isinstance(other, Cartesian3):
+            return Cartesian3(self.x - other.x, self.y - other.y, self.z - other.z)
+        arr = self.to_array() - other
+        return Cartesian3.from_array(arr)
+
+    def __mul__(self, scalar):
+        arr = self.to_array() * scalar
+        return Cartesian3.from_array(arr)
+
+    def __truediv__(self, scalar):
+        arr = self.to_array() / scalar
+        return Cartesian3.from_array(arr)
+
+    def __neg__(self):
+        arr = -self.to_array()
+        return Cartesian3.from_array(arr)
 
     @staticmethod
     def fromSpherical(spherical, result=None):

--- a/satsim/vecmath/Cartesian4.py
+++ b/satsim/vecmath/Cartesian4.py
@@ -1,5 +1,7 @@
 import math
 
+from .backend import xp
+
 
 class Cartesian4:
     """ A 4D Cartesian point. """
@@ -29,6 +31,56 @@ class Cartesian4:
                 self.z == other.z and
                 self.w == other.w)
         )
+
+    # ------------------------------------------------------------------
+    # Convenience helpers using numpy/cupy
+    # ------------------------------------------------------------------
+    def to_array(self):
+        return xp.asarray([self.x, self.y, self.z, self.w], dtype=float)
+
+    @classmethod
+    def from_array(cls, arr):
+        return cls(arr[0], arr[1], arr[2], arr[3])
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+        yield self.z
+        yield self.w
+
+    def __add__(self, other):
+        if isinstance(other, Cartesian4):
+            return Cartesian4(
+                self.x + other.x,
+                self.y + other.y,
+                self.z + other.z,
+                self.w + other.w,
+            )
+        arr = self.to_array() + other
+        return Cartesian4.from_array(arr)
+
+    def __sub__(self, other):
+        if isinstance(other, Cartesian4):
+            return Cartesian4(
+                self.x - other.x,
+                self.y - other.y,
+                self.z - other.z,
+                self.w - other.w,
+            )
+        arr = self.to_array() - other
+        return Cartesian4.from_array(arr)
+
+    def __mul__(self, scalar):
+        arr = self.to_array() * scalar
+        return Cartesian4.from_array(arr)
+
+    def __truediv__(self, scalar):
+        arr = self.to_array() / scalar
+        return Cartesian4.from_array(arr)
+
+    def __neg__(self):
+        arr = -self.to_array()
+        return Cartesian4.from_array(arr)
 
     @staticmethod
     def fromElements(x, y, z, w, result=None):

--- a/satsim/vecmath/Matrix2.py
+++ b/satsim/vecmath/Matrix2.py
@@ -1,5 +1,6 @@
 import math
 from satsim.vecmath import Cartesian2
+from .backend import xp
 
 
 class Matrix2:
@@ -18,7 +19,9 @@ class Matrix2:
             column0Row1: `float`, The value for column 0, row 1.
             column1Row1: `float`, The value for column 1, row 1.
         """
-        self.m = [column0Row0, column0Row1, column1Row0, column1Row1]
+        self.m = xp.asarray(
+            [column0Row0, column0Row1, column1Row0, column1Row1], dtype=float
+        )
 
     def __getitem__(self, key):
         return self.m[key]
@@ -201,7 +204,7 @@ class Matrix2:
             A `list`, The modified Array parameter or a new Array instance if one was not provided.
         """
         if result is None:
-            return [matrix[0], matrix[1], matrix[2], matrix[3]]
+            return xp.asarray([matrix[0], matrix[1], matrix[2], matrix[3]], dtype=float)
 
         result[0] = matrix[0]
         result[1] = matrix[1]

--- a/satsim/vecmath/Matrix3.py
+++ b/satsim/vecmath/Matrix3.py
@@ -1,6 +1,7 @@
 import math
 from satsim.vecmath import Cartesian3
 from satsim.math.const import EPSILON15, EPSILON20
+from .backend import xp
 
 
 class Matrix3:
@@ -33,9 +34,17 @@ class Matrix3:
             column1Row2: `float`, The value for column 1, row 2.
             column2Row2: `float`, The value for column 2, row 2.
         """
-        self.m = [column0Row0, column0Row1, column0Row2,
-                  column1Row0, column1Row1, column1Row2,
-                  column2Row0, column2Row1, column2Row2]
+        self.m = xp.asarray([
+            column0Row0,
+            column0Row1,
+            column0Row2,
+            column1Row0,
+            column1Row1,
+            column1Row2,
+            column2Row0,
+            column2Row1,
+            column2Row2,
+        ], dtype=float)
 
     def __getitem__(self, key):
         return self.m[key]
@@ -457,7 +466,7 @@ class Matrix3:
             A `list`, The modified Array parameter or a new Array instance if one was not provided.
         """
         if result is None:
-            return [
+            return xp.asarray([
                 matrix[0],
                 matrix[1],
                 matrix[2],
@@ -467,7 +476,7 @@ class Matrix3:
                 matrix[6],
                 matrix[7],
                 matrix[8],
-            ]
+            ], dtype=float)
 
         result[0] = matrix[0]
         result[1] = matrix[1]

--- a/satsim/vecmath/Matrix4.py
+++ b/satsim/vecmath/Matrix4.py
@@ -2,6 +2,7 @@ import math
 
 from satsim.vecmath import Cartesian3, Matrix3, Cartesian4
 from satsim.math.const import EPSILON7, EPSILON21
+from .backend import xp
 
 
 class Matrix4:
@@ -28,10 +29,24 @@ class Matrix4:
                  column1Row3=0.0,
                  column2Row3=0.0,
                  column3Row3=0.0):
-        self.m = [column0Row0, column0Row1, column0Row2, column0Row3,
-                  column1Row0, column1Row1, column1Row2, column1Row3,
-                  column2Row0, column2Row1, column2Row2, column2Row3,
-                  column3Row0, column3Row1, column3Row2, column3Row3,]
+        self.m = xp.asarray([
+            column0Row0,
+            column0Row1,
+            column0Row2,
+            column0Row3,
+            column1Row0,
+            column1Row1,
+            column1Row2,
+            column1Row3,
+            column2Row0,
+            column2Row1,
+            column2Row2,
+            column2Row3,
+            column3Row0,
+            column3Row1,
+            column3Row2,
+            column3Row3,
+        ], dtype=float)
         """ Constructor.
 
         Args:
@@ -869,7 +884,7 @@ class Matrix4:
             A `list`, The modified Array parameter or a new Array instance if one was not provided.
         """
         if result is None:
-            return [
+            return xp.asarray([
                 matrix[0],
                 matrix[1],
                 matrix[2],
@@ -886,7 +901,7 @@ class Matrix4:
                 matrix[13],
                 matrix[14],
                 matrix[15],
-            ]
+            ], dtype=float)
 
         result[0] = matrix[0]
         result[1] = matrix[1]

--- a/satsim/vecmath/Quaternion.py
+++ b/satsim/vecmath/Quaternion.py
@@ -2,6 +2,7 @@ import math
 
 from satsim.math.const import EPSILON6
 from satsim.vecmath import Cartesian3, Matrix3
+from .backend import xp
 
 
 class Quaternion:
@@ -32,6 +33,56 @@ class Quaternion:
              self.z == other.z and
              self.w == other.w)
         )
+
+    # ------------------------------------------------------------------
+    # Convenience helpers using numpy/cupy
+    # ------------------------------------------------------------------
+    def to_array(self):
+        return xp.asarray([self.x, self.y, self.z, self.w], dtype=float)
+
+    @classmethod
+    def from_array(cls, arr):
+        return cls(arr[0], arr[1], arr[2], arr[3])
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+        yield self.z
+        yield self.w
+
+    def __add__(self, other):
+        if isinstance(other, Quaternion):
+            return Quaternion(
+                self.x + other.x,
+                self.y + other.y,
+                self.z + other.z,
+                self.w + other.w,
+            )
+        arr = self.to_array() + other
+        return Quaternion.from_array(arr)
+
+    def __sub__(self, other):
+        if isinstance(other, Quaternion):
+            return Quaternion(
+                self.x - other.x,
+                self.y - other.y,
+                self.z - other.z,
+                self.w - other.w,
+            )
+        arr = self.to_array() - other
+        return Quaternion.from_array(arr)
+
+    def __mul__(self, scalar):
+        arr = self.to_array() * scalar
+        return Quaternion.from_array(arr)
+
+    def __truediv__(self, scalar):
+        arr = self.to_array() / scalar
+        return Quaternion.from_array(arr)
+
+    def __neg__(self):
+        arr = -self.to_array()
+        return Quaternion.from_array(arr)
 
     @staticmethod
     def fromAxisAngle(axis, angle, result=None):

--- a/satsim/vecmath/__init__.py
+++ b/satsim/vecmath/__init__.py
@@ -5,3 +5,5 @@ from .Matrix2 import Matrix2
 from .Matrix3 import Matrix3
 from .Matrix4 import Matrix4
 from .Quaternion import Quaternion
+
+from .backend import xp  # expose backend module

--- a/satsim/vecmath/backend.py
+++ b/satsim/vecmath/backend.py
@@ -1,0 +1,4 @@
+try:
+    import cupy as xp
+except Exception:  # pragma: no cover - cupy may not be installed
+    import numpy as xp


### PR DESCRIPTION
## Summary
- implement `backend` module selecting cupy or numpy
- add array helpers and operator overloads to Cartesian vector classes
- use numpy arrays inside vector math functions
- store matrix data as numpy arrays
- keep vector components as numpy scalars

## Testing
- `pytest -q` *(fails to finish in this environment)*
