### PR TITLE
Refactor vecmath Cartesian classes

### DIFF
--- a/satsim/vecmath/Cartesian2.py
+++ b/satsim/vecmath/Cartesian2.py
@@ -4,17 +4,38 @@ from .backend import xp
 
 
 class Cartesian2:
-    """ A 2D Cartesian point. """
+    """A 2D Cartesian point backed by a :mod:`numpy`/``cupy`` array."""
 
     def __init__(self, x=0.0, y=0.0):
-        """ Constructor.
+        """Constructor.
 
-        Args:
-            x: `float`, The X component. default: 0
-            y: `float`, The Y component. default: 0
+        Parameters
+        ----------
+        x : float
+            The X component.
+        y : float
+            The Y component.
         """
-        self.x = x
-        self.y = y
+        self.v = xp.asarray([x, y], dtype=float)
+
+    # ------------------------------------------------------------------
+    # Properties mapping to the underlying array
+    # ------------------------------------------------------------------
+    @property
+    def x(self):
+        return self.v[0]
+
+    @x.setter
+    def x(self, value):
+        self.v[0] = value
+
+    @property
+    def y(self):
+        return self.v[1]
+
+    @y.setter
+    def y(self, value):
+        self.v[1] = value
 
     def __str__(self):
         return str([self.x, self.y])
@@ -29,8 +50,8 @@ class Cartesian2:
     # Convenience helpers using numpy/cupy
     # ------------------------------------------------------------------
     def to_array(self):
-        """Return a 2-element array representation using the configured backend."""
-        return xp.asarray([self.x, self.y], dtype=float)
+        """Return the underlying array without copying."""
+        return self.v
 
     @classmethod
     def from_array(cls, arr):
@@ -524,7 +545,7 @@ class Cartesian2:
         Returns:
             A `boolean`, `True` if equal, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and right is not None and
                 left.x == right.x and left.y == right.y)
@@ -544,7 +565,7 @@ class Cartesian2:
         Returns:
             A `boolean`, `True` if they pass an absolute or relative tolerance test, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and
                 right is not None and

--- a/satsim/vecmath/Cartesian3.py
+++ b/satsim/vecmath/Cartesian3.py
@@ -4,19 +4,44 @@ from .backend import xp
 
 
 class Cartesian3:
-    """ A 3D Cartesian point. """
+    """A 3D Cartesian point backed by a ``numpy``/``cupy`` array."""
 
     def __init__(self, x=0.0, y=0.0, z=0.0):
-        """ Constructor.
+        """Constructor.
 
-        Args:
-            x: `float`, The X component. default: 0
-            y: `float`, The Y component. default: 0
-            z: `float`, The Z component. default: 0
+        Parameters
+        ----------
+        x, y, z : float
+            Cartesian components.
         """
-        self.x = x
-        self.y = y
-        self.z = z
+        self.v = xp.asarray([x, y, z], dtype=float)
+
+    # ------------------------------------------------------------------
+    # Properties mapping to the underlying array
+    # ------------------------------------------------------------------
+    @property
+    def x(self):
+        return self.v[0]
+
+    @x.setter
+    def x(self, value):
+        self.v[0] = value
+
+    @property
+    def y(self):
+        return self.v[1]
+
+    @y.setter
+    def y(self, value):
+        self.v[1] = value
+
+    @property
+    def z(self):
+        return self.v[2]
+
+    @z.setter
+    def z(self, value):
+        self.v[2] = value
 
     def __str__(self):
         return str([self.x, self.y, self.z])
@@ -33,7 +58,8 @@ class Cartesian3:
     # Convenience helpers using numpy/cupy
     # ------------------------------------------------------------------
     def to_array(self):
-        return xp.asarray([self.x, self.y, self.z], dtype=float)
+        """Return the underlying array without copying."""
+        return self.v
 
     @classmethod
     def from_array(cls, arr):
@@ -586,7 +612,7 @@ class Cartesian3:
         Returns:
             A `boolean`, `True` if equal, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and right is not None and
                 left.x == right.x and left.y == right.y and left.z == right.z)
@@ -606,7 +632,7 @@ class Cartesian3:
         Returns:
             A `boolean`, `True` if they pass an absolute or relative tolerance test, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and
                 right is not None and

--- a/satsim/vecmath/Cartesian4.py
+++ b/satsim/vecmath/Cartesian4.py
@@ -4,21 +4,52 @@ from .backend import xp
 
 
 class Cartesian4:
-    """ A 4D Cartesian point. """
+    """A 4D Cartesian point backed by a ``numpy``/``cupy`` array."""
 
     def __init__(self, x=0.0, y=0.0, z=0.0, w=0.0):
-        """ Constructor.
+        """Constructor.
 
-        Args:
-            x: `float`, The X component. default: 0
-            y: `float`, The Y component. default: 0
-            z: `float`, The Z component. default: 0
-            w: `float`, The W component. default: 0
+        Parameters
+        ----------
+        x, y, z, w : float
+            Cartesian components.
         """
-        self.x = x
-        self.y = y
-        self.z = z
-        self.w = w
+        self.v = xp.asarray([x, y, z, w], dtype=float)
+
+    # ------------------------------------------------------------------
+    # Properties mapping to the underlying array
+    # ------------------------------------------------------------------
+    @property
+    def x(self):
+        return self.v[0]
+
+    @x.setter
+    def x(self, value):
+        self.v[0] = value
+
+    @property
+    def y(self):
+        return self.v[1]
+
+    @y.setter
+    def y(self, value):
+        self.v[1] = value
+
+    @property
+    def z(self):
+        return self.v[2]
+
+    @z.setter
+    def z(self, value):
+        self.v[2] = value
+
+    @property
+    def w(self):
+        return self.v[3]
+
+    @w.setter
+    def w(self, value):
+        self.v[3] = value
 
     def __str__(self):
         return str([self.x, self.y, self.z, self.w])
@@ -36,7 +67,8 @@ class Cartesian4:
     # Convenience helpers using numpy/cupy
     # ------------------------------------------------------------------
     def to_array(self):
-        return xp.asarray([self.x, self.y, self.z, self.w], dtype=float)
+        """Return the underlying array without copying."""
+        return self.v
 
     @classmethod
     def from_array(cls, arr):
@@ -525,7 +557,7 @@ class Cartesian4:
         Returns:
             A `boolean`, `True` if equal, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and right is not None and
                 left.x == right.x and left.y == right.y and left.z == right.z and left.w == right.w)
@@ -545,7 +577,7 @@ class Cartesian4:
         Returns:
             A `boolean`, `True` if they pass an absolute or relative tolerance test, `False` otherwise.
         """
-        return (
+        return bool(
             left is right or
             (left is not None and
                 right is not None and


### PR DESCRIPTION
## Summary
- refactor Cartesian2/3/4 to store underlying vectors as xp arrays
- expose vector data directly via properties
- avoid conversions when using numpy/cupy operations

## Testing
- `pytest tests/test_cartesian.py::test_cartesian2 -q`
- `pytest tests/test_cartesian.py::test_cartesian3 -q`
- `pytest tests/test_cartesian.py::test_cartesian4 -q`
- `pytest -q` *(fails: test_eci_to_radec and CLI tests)*