### PR TITLE
Improve annotation with RA/Dec data

### DIFF
--- a/satsim/geometry/analytic_obs.py
+++ b/satsim/geometry/analytic_obs.py
@@ -1,0 +1,115 @@
+from __future__ import division, print_function, absolute_import
+
+import math
+import numpy as np
+
+
+def generate(ssp, obs_os_pix, astrometrics, bg_level, rn):
+    """Generate analytical observations for a frame using precomputed RA/Dec.
+
+    Args:
+        ssp: `dict`, SatSim configuration parameters.
+        obs_os_pix: `list`, list of detected observations in pixel space. Each
+            entry must contain the keys ``ra`` and ``dec`` giving the
+            mid-exposure position of the object.
+        astrometrics: `dict`, frame astrometric parameters.
+        bg_level: `float`, background noise level per pixel.
+        rn: `float`, read noise standard deviation in photo-electrons.
+
+    Notes:
+        ``pixel_error`` is interpreted as the standard deviation of the
+        positional error in pixel units. The error is applied isotropically in
+        the focal plane so that the per-axis standard deviation is
+        ``pixel_error / sqrt(2)``.
+
+    Returns:
+        `list` of observations in the JSON output format.
+    """
+    obs_cfg = ssp['fpa'].get('observation', {})
+    pixel_error = obs_cfg.get('pixel_error', 0.0)
+    snr_threshold = obs_cfg.get('snr_threshold', 0.0)
+    false_alarm_rate = obs_cfg.get('false_alarm_rate', 0.0)
+    max_false = int(obs_cfg.get('max_false', 10))
+
+    height = ssp['fpa'].get('crop', {}).get('height', ssp['fpa']['height'])
+    width = ssp['fpa'].get('crop', {}).get('width', ssp['fpa']['width'])
+
+    y_ifov = astrometrics.get('y_ifov',
+                              ssp['fpa']['y_fov'] / ssp['fpa']['height'])
+    x_ifov = astrometrics.get('x_ifov',
+                              ssp['fpa']['x_fov'] / ssp['fpa']['width'])
+
+    s_osf = ssp['sim'].get('spacial_osf', 1)
+    eod = 1.0
+    if isinstance(ssp['fpa'].get('psf'), dict) and 'eod' in ssp['fpa']['psf']:
+        eod = ssp['fpa']['psf']['eod']
+
+    obs_list = []
+
+    # convert radial pixel error to per-axis standard deviation
+    axis_error = pixel_error / math.sqrt(2.0) if pixel_error else 0.0
+
+    for ob in obs_os_pix:
+        if 'ra' not in ob or 'dec' not in ob:
+            continue
+
+        rr = np.asarray(ob['rr'], dtype=np.int32)
+        cc = np.asarray(ob['cc'], dtype=np.int32)
+        pp = np.asarray(ob['pp'], dtype=float)
+
+        # bin oversampled pixels into real pixel space
+        r_real = rr // s_osf
+        c_real = cc // s_osf
+        bins = {}
+        for r_pix, c_pix, val in zip(r_real, c_real, pp):
+            bins[(r_pix, c_pix)] = bins.get((r_pix, c_pix), 0.0) + val
+
+        if not bins:
+            continue
+
+        peak_signal = max(bins.values()) * eod
+        snr = float(peak_signal / math.sqrt(peak_signal + bg_level + rn * rn))
+        if snr < snr_threshold:
+            continue
+
+        ra_true = ob['ra']
+        dec_true = ob['dec']
+        ra_m = ra_true + np.random.normal(scale=axis_error * x_ifov) / math.cos(math.radians(dec_true))
+        dec_m = dec_true + np.random.normal(scale=axis_error * y_ifov)
+
+        obs_list.append({
+            'obTime': astrometrics['time'].isoformat() + 'Z',
+            'ra': float(ra_m),
+            'declination': float(dec_m),
+            'senlat': astrometrics.get('lat', 0),
+            'senlon': astrometrics.get('lon', 0),
+            'senalt': astrometrics.get('alt', 0),
+            'expDuration': float(ssp['fpa']['time']['exposure']),
+            'createdBy': 'satsim',
+            'type': 'OPTICAL'
+        })
+
+    center_ra = astrometrics.get('ra', 0.0)
+    center_dec = astrometrics.get('dec', 0.0)
+    count = 0
+    while count < max_false and np.random.random() < false_alarm_rate:
+        c_pix = np.random.uniform(-width / 2.0, width / 2.0)
+        r_pix = np.random.uniform(-height / 2.0, height / 2.0)
+        ra_m = center_ra + c_pix * x_ifov / math.cos(math.radians(center_dec))
+        dec_m = center_dec + r_pix * y_ifov
+        ra_m += np.random.normal(scale=axis_error * x_ifov) / math.cos(math.radians(dec_m))
+        dec_m += np.random.normal(scale=axis_error * y_ifov)
+        obs_list.append({
+            'obTime': astrometrics['time'].isoformat() + 'Z',
+            'ra': float(ra_m),
+            'declination': float(dec_m),
+            'senlat': astrometrics.get('lat', 0),
+            'senlon': astrometrics.get('lon', 0),
+            'senalt': astrometrics.get('alt', 0),
+            'expDuration': float(ssp['fpa']['time']['exposure']),
+            'createdBy': 'satsim',
+            'type': 'OPTICAL'
+        })
+        count += 1
+
+    return obs_list

--- a/satsim/geometry/astrometric.py
+++ b/satsim/geometry/astrometric.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 
 import numpy as np
 from pygc import great_circle
-from skyfield.api import Topos, Star, Angle, iers2010
+from skyfield.api import Star, Angle, iers2010
 from skyfield.toposlib import _ltude
 from skyfield.relativity import add_aberration, add_deflection
 from skyfield.earthlib import compute_limb_angle
@@ -276,7 +276,7 @@ def get_los_azel(observer, az, el, t, deflection=False, aberration=True, stellar
         star = Star(ra=ra, dec=dec)
         icrf_los = apparent(observer.at(t).observe(star), deflection, True)
         ra, dec, d = icrf_los.radec()
-        el, az, d = icrf_los.altaz()    
+        el, az, d = icrf_los.altaz()
 
     return ra._degrees, dec._degrees, d.km, az, el, icrf_los
 

--- a/satsim/io/analytical.py
+++ b/satsim/io/analytical.py
@@ -1,0 +1,22 @@
+from __future__ import division, print_function, absolute_import
+
+import json
+import os
+
+
+def save(dir_name, frame_num, obs_list):
+    """Save analytical observations to disk.
+
+    Args:
+        dir_name: `str`, directory where the observation set is stored.
+        frame_num: `int`, frame number being processed.
+        obs_list: `list`, list of observations as returned by
+            `satsim.geometry.analytic_obs.generate`.
+    """
+    obs_dir = os.path.join(dir_name, 'AnalyticalObservations')
+    if not os.path.exists(obs_dir):
+        os.makedirs(obs_dir, exist_ok=True)
+    set_name = os.path.basename(dir_name)
+    file_name = '{}.{:04d}.json'.format(set_name, frame_num)
+    with open(os.path.join(obs_dir, file_name), 'w') as jf:
+        json.dump(obs_list, jf)

--- a/satsim/io/satnet.py
+++ b/satsim/io/satnet.py
@@ -101,6 +101,12 @@ def set_frame_annotation(data,frame_num,height,width,obs,box_size=None,box_pad=0
 
         annotation['pixels'] = opix
         annotation['snr'] = osnr
+        if 'ra' in o and 'dec' in o:
+            annotation['ra'] = _cast_to_float(o['ra'])
+            annotation['dec'] = _cast_to_float(o['dec'])
+        if 'ra_true' in o and 'dec_true' in o:
+            annotation['ra_true'] = _cast_to_float(o['ra_true'])
+            annotation['dec_true'] = _cast_to_float(o['dec_true'])
         objs.append(annotation)
 
     if star_os_pix is not None:

--- a/satsim/satsim.py
+++ b/satsim/satsim.py
@@ -37,6 +37,8 @@ from satsim.io.satnet import write_frame, set_frame_annotation, init_annotation
 from satsim.io.image import save_apng
 from satsim.io.czml import save_czml
 from satsim.util import tic, toc, MultithreadedTaskQueue, configure_eager, configure_single_gpu, merge_dicts
+from satsim.geometry import analytic_obs
+from satsim.io import analytical
 from satsim.config import transform, save_debug, _transform, save_cache
 from satsim.pipeline import _delta_t, _avg_t
 from satsim import time
@@ -156,7 +158,7 @@ def gen_images(ssp, eager=True, output_dir='./', sample_num=0, output_debug=Fals
         x_ifov)
 
     astrometrics_list = []
-    for fpa_digital, frame_num, astrometrics, obs_os_pix, fpa_conv_star, fpa_conv_targ, bg_tf, dc_tf, rn_tf, num_shot_noise_samples, obs_cache, ground_truth, star_os_pix, segmentation in image_generator(ssp, output_dir, output_debug, dir_debug, with_meta=True, num_sets=1):
+    for fpa_digital, frame_num, astrometrics, obs_os_pix, fpa_conv_star, fpa_conv_targ, bg_tf, dc_tf, rn_tf, num_shot_noise_samples, obs_cache, ground_truth, star_os_pix, segmentation in image_generator(ssp, dir_name, output_debug, dir_debug, with_meta=True, num_sets=1):
         astrometrics_list.append(astrometrics)
         if fpa_digital is not None:
             snr = signal_to_noise_ratio(fpa_conv_targ, fpa_conv_star + bg_tf + dc_tf, rn_tf)
@@ -349,6 +351,19 @@ def image_generator(ssp, output_dir='.', output_debug=False, dir_debug='./Debug'
     if 'flip_left_right' not in ssp['fpa']:
         ssp['fpa']['flip_left_right'] = False
 
+    if 'observation' not in ssp['fpa']:
+        ssp['fpa']['observation'] = {
+            'snr_threshold': 0.0,
+            'pixel_error': 0.0,
+            'false_alarm_rate': 0.0,
+            'max_false': 10,
+        }
+    else:
+        ssp['fpa']['observation'].setdefault('snr_threshold', 0.0)
+        ssp['fpa']['observation'].setdefault('pixel_error', 0.0)
+        ssp['fpa']['observation'].setdefault('false_alarm_rate', 0.0)
+        ssp['fpa']['observation'].setdefault('max_false', 10)
+
     star_mode = ssp['geometry']['stars']['mode']
 
     # TODO move defaults to a different file
@@ -410,6 +425,9 @@ def image_generator(ssp, output_dir='.', output_debug=False, dir_debug='./Debug'
 
     if 'save_pickle' not in ssp['sim']:
         ssp['sim']['save_pickle'] = False
+
+    if 'analytical_obs' not in ssp['sim']:
+        ssp['sim']['analytical_obs'] = False
 
     if 'psf_sample_frequency' not in ssp['sim']:
         ssp['sim']['psf_sample_frequency'] = 'once'
@@ -854,6 +872,19 @@ def image_generator(ssp, output_dir='.', output_debug=False, dir_debug='./Debug'
             else:
                 ground_truth = None
 
+            if ssp['sim'].get('analytical_obs', False):
+                bg_val = float(tf.reduce_mean(crop_bg_tf).numpy()) if hasattr(crop_bg_tf, 'numpy') else float(np.mean(crop_bg_tf))
+                rn_val = float(tf.reduce_mean(crop_rn_tf).numpy()) if hasattr(crop_rn_tf, 'numpy') else float(np.mean(crop_rn_tf))
+
+                obs_list = analytic_obs.generate(
+                    ssp,
+                    obs_os_pix,
+                    astrometrics,
+                    bg_val,
+                    rn_val,
+                )
+                analytical.save(output_dir, frame_num, obs_list)
+
             if output_debug:
                 if fpa_os_w_targets is not None:
                     with open(os.path.join(dir_debug, 'fpa_os_{}.pickle'.format(frame_num)), 'wb') as picklefile:
@@ -1010,7 +1041,26 @@ def _gen_objects(ssp, render_mode,
             az, el = _calculate_az_el(tc_start, tc_end, [ts_start, ts_mid, ts_end], track_az, track_el)
 
             try:
-                [rr0, rr1, rr2], [cc0, cc1, cc2], _, _, _ = gen_track(h_fpa_os, w_fpa_os, y_fov, x_fov, observer, track, [target], [ope], tc_start, [ts_start, ts_mid, ts_end], star_rot, 1, track_mode, offset=o_offset, flipud=ssp['fpa']['flip_up_down'], fliplr=ssp['fpa']['flip_left_right'], az=az, el=el)
+                [rr0, rr1, rr2], [cc0, cc1, cc2], _, _, _ = gen_track(
+                    h_fpa_os,
+                    w_fpa_os,
+                    y_fov,
+                    x_fov,
+                    observer,
+                    track,
+                    [target],
+                    [ope],
+                    tc_start,
+                    [ts_start, ts_mid, ts_end],
+                    star_rot,
+                    1,
+                    track_mode,
+                    offset=o_offset,
+                    flipud=ssp['fpa']['flip_up_down'],
+                    fliplr=ssp['fpa']['flip_left_right'],
+                    az=az,
+                    el=el,
+                )
             except Exception:
                 logger.exception("Error propagating target. {}".format(o))
                 continue
@@ -1071,7 +1121,34 @@ def _gen_objects(ssp, render_mode,
             occc = np.concatenate((occc, occ))
             oppp = np.concatenate((oppp, opp))
 
-        obs_os_pix.append({
+        if obs_cache[i] is not None:
+            ra_mid, dec_mid, _, _, _, _ = get_los(
+                observer,
+                target,
+                ts_mid,
+                deflection=False,
+                aberration=True,
+                stellar_aberration=False,
+            )
+            ra_true, dec_true, _, _, _, _ = get_los(
+                observer,
+                target,
+                ts_mid,
+                deflection=False,
+                aberration=False,
+                stellar_aberration=False,
+            )
+            ra_mid = float(ra_mid)
+            dec_mid = float(dec_mid)
+            ra_true = float(ra_true)
+            dec_true = float(dec_true)
+        else:
+            ra_mid = None
+            dec_mid = None
+            ra_true = None
+            dec_true = None
+
+        entry = {
             'rr': orr,
             'cc': occ,
             'pp': opp,
@@ -1082,7 +1159,14 @@ def _gen_objects(ssp, render_mode,
             'id': i + 1,  # 0 is reserved for the background for segmentation
             'object_name': object_name,
             'object_id': object_id,
-        })
+        }
+        if ra_mid is not None and dec_mid is not None:
+            entry['ra'] = ra_mid
+            entry['dec'] = dec_mid
+            entry['ra_true'] = ra_true
+            entry['dec_true'] = dec_true
+
+        obs_os_pix.append(entry)
 
     return orrr, occc, oppp, obs_os_pix, obs_model
 
@@ -1165,5 +1249,4 @@ def _parse_start_track_time(track_mode, frame_num, total_frames, ts_collect_star
             return ts_collect_start
         else:
             return ts_start
-
     return ts_collect_start

--- a/schema/v1/Fpa.json
+++ b/schema/v1/Fpa.json
@@ -73,6 +73,29 @@
                 }
             }
         },
+        "observation": {
+            "description": "Parameters for synthetic observations.",
+            "type": "object",
+            "properties": {
+                "snr_threshold": {
+                    "description": "SNR threshold for detection.",
+                    "$ref": "types/Float.json"
+                },
+                "pixel_error": {
+                    "description": "Standard deviation of pixel error.",
+                    "$ref": "types/Float.json"
+                },
+                "false_alarm_rate": {
+                    "description": "Probability of false alarm per iteration.",
+                    "$ref": "types/Float.json"
+                },
+                "max_false": {
+                    "description": "Maximum number of false alarms to inject per frame.",
+                    "$ref": "types/Integer.json",
+                    "default": 10
+                }
+            }
+        },
         "psf": {
             "description": "The point spread function of the focal plane array.",
             "$ref": "types/Psf.json"

--- a/schema/v1/Sim.json
+++ b/schema/v1/Sim.json
@@ -135,6 +135,11 @@
             "type": "boolean",
             "default": false
         },
+        "analytical_obs": {
+            "description": "Generate analytical observations instead of images.",
+            "type": "boolean",
+            "default": false
+        },
         "czml_samples": {
             "description": "The number of object position samples to save in the CZML file.",
             "type": "integer",

--- a/tests/test_analytic_obs_error.py
+++ b/tests/test_analytic_obs_error.py
@@ -1,0 +1,48 @@
+import datetime
+import numpy as np
+from satsim.geometry import analytic_obs
+
+
+def test_pixel_error_distribution():
+    ssp = {
+        'fpa': {
+            'width': 100,
+            'height': 100,
+            'x_fov': 1.0,
+            'y_fov': 1.0,
+            'time': {'exposure': 1.0},
+            'psf': {'eod': 1.0},
+            'observation': {
+                'pixel_error': 1.0,
+                'snr_threshold': 0.0,
+                'false_alarm_rate': 0.0,
+                'max_false': 0,
+            },
+        },
+        'sim': {'spacial_osf': 1},
+    }
+
+    astrometrics = {
+        'time': datetime.datetime.utcnow(),
+        'x_ifov': ssp['fpa']['x_fov'] / ssp['fpa']['width'],
+        'y_ifov': ssp['fpa']['y_fov'] / ssp['fpa']['height'],
+    }
+
+    obs_os_pix = [{
+        'rr': [0],
+        'cc': [0],
+        'pp': [100],
+        'ra': 0.0,
+        'dec': 0.0,
+    }]
+
+    deltas = []
+    for _ in range(2000):
+        obs = analytic_obs.generate(ssp, obs_os_pix, astrometrics, 0.0, 0.0)
+        delta_ra_pix = (obs[0]['ra']) * np.cos(0.0) / astrometrics['x_ifov']
+        delta_dec_pix = obs[0]['declination'] / astrometrics['y_ifov']
+        deltas.append([delta_ra_pix, delta_dec_pix])
+
+    arr = np.asarray(deltas)
+    axis_std = np.std(arr, axis=0)
+    assert np.allclose(axis_std, np.ones(2) / np.sqrt(2), rtol=0.1, atol=0.1)

--- a/tests/test_analytical_obs.py
+++ b/tests/test_analytical_obs.py
@@ -1,0 +1,136 @@
+import os
+import json
+import copy
+from satsim import config, gen_images
+from satsim.util import MultithreadedTaskQueue
+from tests.test_satsim import _gen_name
+
+
+def test_analytical_observations():
+    ssp = config.load_json('./tests/config_static.json')
+    ssp['sim']['analytical_obs'] = True
+    ssp['fpa']['observation'] = {
+        'snr_threshold': 0.0,
+        'pixel_error': 0.5,
+        'false_alarm_rate': 1.0,
+        'max_false': 2
+    }
+    ssp['fpa']['num_frames'] = 1
+    ssp['geometry']['site'] = {
+        "mode": "topo",
+        "lat": "20.746111 N",
+        "lon": "156.431667 W",
+        "alt": 0.0,
+        "gimbal": {"mode": "wcs", "rotation": 0},
+        "track": {"mode": "fixed", "az": 0, "el": 90}
+    }
+    ssp['geometry']['obs']['list'] = [
+        {
+            "mode": "line",
+            "origin": [0.5, 0.5],
+            "velocity": [0, 0],
+            "mv": 10
+        }
+    ]
+
+    queue = MultithreadedTaskQueue()
+    set_name = _gen_name('analytical')
+    dirname = gen_images(copy.deepcopy(ssp), eager=True, output_dir='./.images', output_debug=True, queue=queue, set_name=set_name)
+    queue.waitUntilEmpty()
+
+    assert os.path.isdir(dirname)
+    obs_dir = os.path.join(dirname, 'AnalyticalObservations')
+    files = [f for f in os.listdir(obs_dir) if f.endswith('.json')]
+    assert len(files) == 1
+    with open(os.path.join(obs_dir, files[0])) as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    assert len(data) >= ssp['fpa']['observation']['max_false']
+    assert len(data) <= ssp['fpa']['observation']['max_false'] + 1
+
+
+def test_analytical_observations_threshold():
+    ssp = config.load_json('./tests/config_static.json')
+    ssp['sim']['analytical_obs'] = True
+    ssp['fpa']['observation'] = {
+        'snr_threshold': 1e6,
+        'pixel_error': 0.0,
+        'false_alarm_rate': 1.0,
+        'max_false': 3
+    }
+    ssp['fpa']['num_frames'] = 1
+    ssp['geometry']['site'] = {
+        "mode": "topo",
+        "lat": "20.746111 N",
+        "lon": "156.431667 W",
+        "alt": 0.0,
+        "gimbal": {"mode": "wcs", "rotation": 0},
+        "track": {"mode": "fixed", "az": 0, "el": 90}
+    }
+    ssp['geometry']['obs']['list'] = [
+        {
+            "mode": "line",
+            "origin": [0.5, 0.5],
+            "velocity": [0, 0],
+            "mv": 10
+        }
+    ]
+
+    queue = MultithreadedTaskQueue()
+    set_name = _gen_name('analytical2')
+    dirname = gen_images(copy.deepcopy(ssp), eager=True, output_dir='./.images', output_debug=True, queue=queue, set_name=set_name)
+    queue.waitUntilEmpty()
+
+    obs_dir = os.path.join(dirname, 'AnalyticalObservations')
+    files = [f for f in os.listdir(obs_dir) if f.endswith('.json')]
+    with open(os.path.join(obs_dir, files[0])) as f:
+        data = json.load(f)
+
+    assert len(data) == ssp['fpa']['observation']['max_false']
+
+
+def test_truth_annotation_ra_dec():
+    ssp = config.load_json('./tests/config_static.json')
+    ssp['fpa']['num_frames'] = 1
+    ssp['geometry']['site'] = {
+        "mode": "topo",
+        "lat": "20.746111 N",
+        "lon": "156.431667 W",
+        "alt": 0.0,
+        "gimbal": {"mode": "wcs", "rotation": 0},
+        "track": {"mode": "fixed", "az": 0, "el": 90}
+    }
+    from satsim.geometry.astrometric import create_topocentric, get_los_azel
+    from satsim import time
+
+    ts = time.utc(2020, 1, 1, 0, 0, 0)
+    topo = create_topocentric("20.746111 N", "156.431667 W", 0.0)
+    ra_c, dec_c, _, _, _, _ = get_los_azel(topo, 0, 90, ts,
+                                           deflection=False, aberration=False)
+
+    ssp['geometry']['obs']['list'] = [
+        {
+            "mode": "observation",
+            "ra": ra_c,
+            "dec": dec_c,
+            "time": [2020, 1, 1, 0, 0, 0],
+            "range": 1000.0,
+            "mv": 10
+        }
+    ]
+
+    queue = MultithreadedTaskQueue()
+    set_name = _gen_name('truthra')
+    dirname = gen_images(copy.deepcopy(ssp), eager=True, output_dir='./.images',
+                         output_debug=True, queue=queue, set_name=set_name)
+    queue.waitUntilEmpty()
+
+    anno_dir = os.path.join(dirname, 'Annotations')
+    files = [f for f in os.listdir(anno_dir) if f.endswith('.json')]
+    with open(os.path.join(anno_dir, files[0])) as f:
+        data = json.load(f)
+
+    found = any('ra_true' in ob and 'ra' in ob
+                for ob in data['data']['objects']
+                if ob['class_name'] == 'Satellite')
+    assert found

--- a/tests/test_satnet.py
+++ b/tests/test_satnet.py
@@ -19,7 +19,11 @@ def test_annotation():
         'rr': orr,
         'cc': occ,
         'mv': 15,
-        'pe': 100
+        'pe': 100,
+        'ra': 1.0,
+        'dec': -1.0,
+        'ra_true': 0.5,
+        'dec_true': -0.5,
     }
 
     a = init_annotation('./', 0, h, w, 2., 3.)
@@ -37,6 +41,11 @@ def test_annotation():
 
     assert(c['y_center'] == (0.55 + 0.75) / 2.)
     assert(c['x_center'] == (0.525 + 0.575) / 2.)
+
+    assert c['ra'] == 1.0
+    assert c['dec'] == -1.0
+    assert c['ra_true'] == 0.5
+    assert c['dec_true'] == -0.5
 
     assert(c['seg_id'] == -1)
 


### PR DESCRIPTION
## Summary
- include mid-time astrometric and true RA/Dec when generating objects
- write RA/Dec metadata into annotation files
- exercise new metadata in unit tests

## Testing
- `make lint`
- `pytest -q tests/test_satnet.py::test_annotation tests/test_analytical_obs.py::test_truth_annotation_ra_dec tests/test_analytic_obs_error.py`

------
https://chatgpt.com/codex/tasks/task_e_68365bad8a94832da7436d0fb4a2ddaa